### PR TITLE
Use com.sublimetext.three as a name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILDER_OPTIONS = --force-clean --ccache --require-changes
 TARGET_REPO = repo
 FLATPAK_BUILDER = $(shell which flatpak-builder)
-MANIFEST = com.sublimetext.Sublime.json
+MANIFEST = com.sublimetext.three.json
 
 all: build
 

--- a/apply_extra
+++ b/apply_extra
@@ -6,7 +6,7 @@ rm -f control.tar.gz data.tar.lzma debian-binary
 mv usr/* .
 rmdir usr
 mkdir -p export/share/applications
-sed s/Icon=sublime-text/Icon=com.sublimetext.Sublime/ share/applications/sublime_text.desktop > export/share/applications/com.sublimetext.Sublime.desktop
+sed s/Icon=sublime-text/Icon=com.sublimetext.three/ share/applications/sublime_text.desktop > export/share/applications/com.sublimetext.three.desktop
 mkdir -p export/share/icons/hicolor/256x256/apps
-cp share/icons/hicolor/256x256/apps/sublime-text.png export/share/icons/hicolor/256x256/apps/com.sublimetext.Sublime.png
+cp share/icons/hicolor/256x256/apps/sublime-text.png export/share/icons/hicolor/256x256/apps/com.sublimetext.three.png
 sed -i 's:/opt/sublime_text/sublime_text:/app/extra/opt/sublime_text/sublime_text:' /app/extra/bin/subl

--- a/com.sublimetext.three.json
+++ b/com.sublimetext.three.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "com.sublimetext.Sublime",
+    "app-id": "com.sublimetext.three",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.22",
     "sdk": "org.gnome.Sdk",

--- a/metadata
+++ b/metadata
@@ -1,4 +1,4 @@
 [Application]
-name=com.sublimetext.Sublime
+name=com.sublimetext.three
 runtime=org.gnome.Platform/x86_64/3.22
 sdk=org.gnome.Sdk/x86_64/3.22

--- a/sublime.flatpakref.in
+++ b/sublime.flatpakref.in
@@ -1,6 +1,6 @@
 [Flatpak Ref]
 Title=Sublime
-Name=com.sublimetext.Sublime
+Name=com.sublimetext.three
 Branch=master
 Url=@URL@
 IsRuntime=False


### PR DESCRIPTION
This is the dbus name flatpak would allow access to by default - and Sublime
would crash if the name is not found or doesn't match


This resolves a GLib crash on a version from master